### PR TITLE
Add minimal TypeScript type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+declare module "php" {
+    export async function __express(template: any, model: any, callback: any): Promise<any>;
+    export function disableRegisterGlobalModel(): void;
+    export function enableRegisterGlobalModel(): void;
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "version": "1.0.1",
   "files": [
+    "index.d.ts",
     "index.js",
     "loader.php"
   ],


### PR DESCRIPTION
This fixes #41, and allows the module to be used in TypeScript projects
without any errors or warnings.